### PR TITLE
Declare `response` variable

### DIFF
--- a/src/getter.js
+++ b/src/getter.js
@@ -18,7 +18,7 @@ exports.getJSON = async (values, url, cb) => {
             }
             return cachedResult
         } else {
-            response = await axios.get(url, options)
+            let response = await axios.get(url, options)
             // if there is an error
             if (response.statusCode !== undefined && response.statusCode !== 200) {
                 handleError(response, cb)


### PR DESCRIPTION
Otherwise, it fails when compiling it in strict mode.

Fixes #49 