### PR TITLE
Fix ListEndpointOptions interface in typings file

### DIFF
--- a/generator/TypesGenerator.ts
+++ b/generator/TypesGenerator.ts
@@ -71,7 +71,7 @@ async function generateFinalFile(types: string) {
   namespace.formatText();
 
   // Add the root endpoint interval
-  namespace.addInterface({
+  rootModule.addInterface({
     name: 'ListEndpointOptions',
     properties: [{
       name: 'offset',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pokedex-promise-v2",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokedex-promise-v2",
   "type": "module",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A library used to get information about Pokemons.",
   "engines": {
     "node": ">=12"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1978,15 +1978,15 @@ declare module 'pokedex-promise-v2' {
             /** The versions this version group owns. */
             versions: NamedAPIResource[];
         }
+    }
 
-        interface ListEndpointOptions {
-            /** The offset to be used in the request */
-            offset?: number;
-            /** The limit to be used in the request */
-            limit?: number;
-            /** The limit of the cache in milliseconds */
-            cacheLimit?: number;
-        }
+    interface ListEndpointOptions {
+        /** The offset to be used in the request */
+        offset?: number;
+        /** The limit to be used in the request */
+        limit?: number;
+        /** The limit of the cache in milliseconds */
+        cacheLimit?: number;
     }
 
     interface PokeAPIOptions {


### PR DESCRIPTION
Should resolve #55. It seems the npm module didn't have a reference to the interface `ListEndpointOptions`, so I modified the generator file to use the `PokeAPI.ListEndpointOptions` interface in the `index.d.ts` file.