### PR TITLE
fix: convert cacheLimit from ms to seconds for node-cache ttl

### DIFF
--- a/dist/src/utils/Getter.js
+++ b/dist/src/utils/Getter.js
@@ -29,8 +29,10 @@ async function getJSON(values, url, callback) {
         const responseData = response.data;
         // Cache the object in memory-cache
         // only if cacheLimit > 0
+        // node-cache's ttl is in seconds, but cacheLimit is documented
+        // (and defaulted) in milliseconds, so convert here
         if (values.cacheLimit > 0) {
-            values.cache.set(url, responseData, values.cacheLimit);
+            values.cache.set(url, responseData, values.cacheLimit / 1000);
         }
         // If a callback is present
         if (callback) {

--- a/src/utils/Getter.ts
+++ b/src/utils/Getter.ts
@@ -44,8 +44,10 @@ async function getJSON<T>(
 
     // Cache the object in memory-cache
     // only if cacheLimit > 0
+    // node-cache's ttl is in seconds, but cacheLimit is documented
+    // (and defaulted) in milliseconds, so convert here
     if (values.cacheLimit > 0) {
-      values.cache.set<T>(url, responseData, values.cacheLimit);
+      values.cache.set<T>(url, responseData, values.cacheLimit / 1000);
     }
 
     // If a callback is present

--- a/test/CacheLimit.spec.ts
+++ b/test/CacheLimit.spec.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+
+import Pokedex from '../src/index.js';
+
+// cacheLimit is documented (and defaulted) in milliseconds, e.g. the README
+// example `cacheLimit: 100 * 1000 // 100s`. node-cache's own `ttl` option is
+// in seconds, so without a ms -> s conversion a cacheLimit of 100 * 1000 ends
+// up living for 100 * 1000 seconds instead of 100 seconds (1000x too long).
+describe('cacheLimit', function () {
+  this.timeout(10000);
+
+  it('applies cacheLimit as milliseconds, not seconds', async () => {
+    const cacheLimit = 100 * 1000; // 100 seconds, expressed in ms
+    const P = new Pokedex({ cacheLimit });
+
+    const before = Date.now();
+    const { name } = await P.getPokemonByName('eevee');
+    assert.strictEqual(name, 'eevee');
+
+    const url = 'https://pokeapi.co/api/v2/pokemon/eevee/';
+    const impliedMs = P.getConfig().cache.getTtl(url) - before;
+
+    // Must stay close to cacheLimit (100000ms). The bug passed the ms value
+    // straight to node-cache's seconds-based ttl, producing ~1000x this.
+    assert.ok(
+      impliedMs < cacheLimit * 2,
+      `expected TTL close to ${cacheLimit}ms, got ${impliedMs}ms`,
+    );
+  });
+});


### PR DESCRIPTION
### Problem

`cacheLimit` is documented and typed in milliseconds:

- README: "`cacheLimit` in ms", example `cacheLimit: 100 * 1000, // 100s`
- `PokeAPIOptions`: default `1000000 * 1000 // 11 days`
- The sibling `timeout` option is also in ms (passed straight to axios).

But `Getter.ts` passes `cacheLimit` straight into node-cache's `set(key, val, ttl)`, whose `ttl` is in **seconds** (node-cache computes `livetime = now + ttl * 1000`). So the ms value ends up multiplied by 1000.

This dates back to `7b97e69` ("Swap memory-cache for node-cache"): `memory-cache` used milliseconds, node-cache uses seconds, and the swap did not add a conversion. The stale `// Cache the object in memory-cache` comment and the unused `@types/memory-cache` dependency are leftovers from that migration.

### Repro (before fix, live)

```js
const P = new Pokedex({ cacheLimit: 100 * 1000 }); // README's "100s" example
await P.getPokemonByName('eevee');
P.getConfig().cache.getTtl(url) - Date.now();
// ~100,000,000 ms  (about 27.8 hours, not the documented 100s)
```

With defaults, the effective cache duration is `1000000 * 1000` seconds, about **31.7 years** instead of the documented ~11 days, so entries effectively never expire and stale data is never refreshed.

### Fix

Convert at the node-cache call site only (`cacheLimit / 1000`); the public ms-based option is unchanged. After the fix the same measurement gives ~100,000 ms, and defaults give ~11 days.

### Test

`test/CacheLimit.spec.ts` measures `cache.getTtl()` and asserts it stays close to the configured `cacheLimit` rather than 1000x larger. It fails on the old code and passes with the fix. Full suite: 230 passing.

### Note on behavior change

node-cache is in-memory, so this only affects long-running processes: entries that used to live effectively forever (default ~31.7 years) now expire per the documented duration (~11 days by default). No option name, type, or signature changed, only the actual cache duration, which now matches what you configure. Callers who set `cacheLimit` by the README will now get the documented behavior.

---
Investigated and implemented with the help of an AI coding assistant; verified via the `getTtl` measurements and the test above.
