### PR TITLE
fix: remove off-by-one shift on constructor offset option

### DIFF
--- a/dist/src/interfaces/PokeAPIOptions.js
+++ b/dist/src/interfaces/PokeAPIOptions.js
@@ -18,7 +18,7 @@ class PokeAPIOptions {
             this.versionPath = config.versionPath;
         }
         if (config.offset) {
-            this.offset = config.offset - 1;
+            this.offset = config.offset;
         }
         if (config.limit) {
             this.limit = config.limit;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokedex-promise-v2",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokedex-promise-v2",
-      "version": "4.2.3",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokedex-promise-v2",
   "type": "module",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "description": "A library used to get information about Pokemons.",
   "engines": {
     "node": ">=18"

--- a/src/interfaces/PokeAPIOptions.ts
+++ b/src/interfaces/PokeAPIOptions.ts
@@ -60,7 +60,7 @@ class PokeAPIOptions {
       this.versionPath = config.versionPath;
     }
     if (config.offset) {
-      this.offset = config.offset - 1;
+      this.offset = config.offset;
     }
     if (config.limit) {
       this.limit = config.limit;


### PR DESCRIPTION
### Problem

The same `offset` option behaves differently depending on how it is passed:

```js
new Pokedex({ offset: 10 }).getPokemonsList(); // requests offset=9  (constructor path)
P.getPokemonsList({ offset: 10 });             // requests offset=10 (per-call path)
```

`PokeAPIOptions` subtracts 1 from a constructor-level `offset`:

```ts
if (config.offset) {
  this.offset = config.offset - 1;
}
```

while the per-call path (`index.ts`) uses the value as-is (`offset = interval.offset`). The README documents `offset` as "where to start. The first item that you will get. Default `0`", which matches the raw/per-call behavior, not the shifted constructor behavior.

### Repro (before fix, live API)

```js
new PokeAPIOptions({ offset: 10 }, cache).offset;  // 9 (expected 10)

new Pokedex({ offset: 10 }).getPokemonsList();     // first result: caterpie (id 10)
P.getPokemonsList({ offset: 10 });                 // first result: metapod (id 11)
```

Same option, two different results.

### Fix

Remove the `- 1` so a constructor-level `offset` matches the per-call path and the documented behavior. `offset: 0` (the default) is unaffected, since `config.offset` is falsy for `0`.

### Test

`test/Offset.spec.ts` asserts the stored offset is unshifted and that the resulting list starts at the requested index. Both fail on the old code and pass with the fix. Full suite: 231 passing.

### Note on behavior change

Callers who set a constructor-level `offset` will now get results one position later, matching the per-call path and the README. Only the constructor path changes; `offset: 0`/unset and per-call `offset` are unaffected.

### Re: the README's `offset: 34` example

The offset section's worked example ("This call will get the list of pokemon between ID 34 and ID 44") shows a first result of `nidoking` (id 34) for `offset: 34`, which looks like a `-1` shift, the opposite of what this PR argues for. That example is on the per-call path, which this PR does not touch, and it predates the current API (its `"count": 811` is the original ~810-species snapshot). It does not reproduce today: live, `offset: 34` returns `clefairy` (id 35), unshifted, on both `master` and this branch. It is the same stale doc as the `"count": 811` beside it, not a spec for current behavior.

---
Investigated and implemented with the help of an AI coding assistant; verified against the live API before opening this PR.
